### PR TITLE
add config locale helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ obj/
 riderModule.iml
 /_ReSharper.Caches/
 build/
+.vs/

--- a/ConfigLocale.cs
+++ b/ConfigLocale.cs
@@ -1,4 +1,5 @@
-﻿using Elements.Core;
+﻿using BepInEx.Configuration;
+using Elements.Core;
 
 namespace BepisLocaleLoader;
 
@@ -19,4 +20,62 @@ public struct ConfigLocale
 
     public LocaleString Name;
     public LocaleString Description;
+}
+
+public static class ConfigLocaleHelper
+{
+    /// <summary>
+    /// Create a new setting with localized name and description. The resulting locale keys will be: Name = Settings.{guid}.{section}.{key}, Description = Settings.{guid}.{section}.{key}.Description
+    /// </summary>
+    /// <typeparam name="T">Type of the value contained in this setting.</typeparam>
+    /// <param name="config">The file that the setting will be bound to.</param>
+    /// <param name="guid">The GUID of your mod, this is used to make the locale key unique from other plugins.</param>
+    /// <param name="section">Section/category/group of the setting. Settings are grouped by this.</param>
+    /// <param name="key">Name of the setting.</param>
+    /// <param name="defaultValue">Value of the setting if the setting was not created yet.</param>
+    /// <param name="englishDescription">The english description of your config key. This will be visible when editing config files via mod managers or manually.</param>
+    public static ConfigEntry<T> BindLocalized<T>(this ConfigFile config, string guid, string section, string key, T defaultValue, string englishDescription)
+    {
+        return config.BindLocalized(guid, new ConfigDefinition(section, key), defaultValue, new ConfigDescription(englishDescription));
+    }
+
+    /// <summary>
+    /// Create a new setting with localized name and description. The resulting locale keys will be: Name = Settings.{guid}.{section}.{key}, Description = Settings.{guid}.{section}.{key}.Description
+    /// </summary>
+    /// <typeparam name="T">Type of the value contained in this setting.</typeparam>
+    /// <param name="config">The file that the setting will be bound to.</param>
+    /// <param name="guid">The GUID of your mod, this is used to make the locale key unique from other plugins.</param>
+    /// <param name="section">Section/category/group of the setting. Settings are grouped by this.</param>
+    /// <param name="key">Name of the setting.</param>
+    /// <param name="defaultValue">Value of the setting if the setting was not created yet.</param>
+    /// <param name="configDescription">Description and other metadata of the setting. The text description will be visible when editing config files via mod managers or manually.</param>
+    public static ConfigEntry<T> BindLocalized<T>(this ConfigFile config, string guid, string section, string key, T defaultValue, ConfigDescription configDescription = null)
+    {
+        return config.BindLocalized(guid, new ConfigDefinition(section, key), defaultValue, configDescription);
+    }
+
+    /// <summary>
+    /// Create a new setting with localized name and description. The resulting locale keys will be: Name = Settings.{guid}.{Section}.{Key}, Description = Settings.{guid}.{Section}.{Key}.Description
+    /// </summary>
+    /// <typeparam name="T">Type of the value contained in this setting.</typeparam>
+    /// <param name="config">The file that the setting will be bound to.</param>
+    /// <param name="guid">The GUID of your mod, this is used to make the locale key unique from other plugins.</param>
+    /// <param name="configDefinition">Section and Key of the setting.</param>
+    /// <param name="defaultValue">Value of the setting if the setting was not created yet.</param>
+    /// <param name="configDescription">Description and other metadata of the setting. The text description will be visible when editing config files via mod managers or manually.</param>
+    public static ConfigEntry<T> BindLocalized<T>(this ConfigFile config, string guid, ConfigDefinition configDefinition, T defaultValue, ConfigDescription configDescription = null)
+    {
+        var localeName = $"Settings.{guid}.{configDefinition.Section}.{configDefinition.Key}";
+        var localeDescription = localeName + ".Description";
+        var locale = new ConfigLocale(localeName, localeDescription);
+        if(configDescription == null)
+        {
+            configDescription = new ConfigDescription(string.Empty, null, locale);
+        }
+        else
+        {
+            configDescription = new ConfigDescription(configDescription.Description, configDescription.AcceptableValues, [..configDescription.Tags, locale]);
+        }
+        return config.Bind(configDefinition, defaultValue, configDescription);
+    }
 }


### PR DESCRIPTION
allows you to easily define localized config keys. this means you replace

`Config.Bind("Section", "Key", false, "My english description.");`
with
`Config.BindLocalized(PluginMetadata.GUID, "Section", "Key", false, "My english description.");`
and it will automatically define some config keys for you.

the english description is still needed for mod managers and config ini files to have a description.